### PR TITLE
Validate Proto Zip

### DIFF
--- a/packages/publisher-dapp/package.json
+++ b/packages/publisher-dapp/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.12.0",
     "@sentry/browser": "^5.10.2",
+    "jszip": "^3.3.0",
     "lodash": "latest",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/packages/publisher-dapp/src/Pages/AiServiceCreation/PricingDistribution/UploadProto/index.js
+++ b/packages/publisher-dapp/src/Pages/AiServiceCreation/PricingDistribution/UploadProto/index.js
@@ -36,12 +36,13 @@ const UploadProto = ({ changeProtoFiles }) => {
     return new Promise((resolve, reject) => {
       const zip = new JSZip();
       zip.loadAsync(uploadedFile).then(entry => {
-        Object.values(entry.files).forEach(file => {
+        const someFileIsNotAProto = Object.values(entry.files).some(file => {
           const fileExtn = last(file.name.split("."));
-          if (fileExtn !== protoFilesExtn) {
-            reject(new ValidationError("The zip file should contain only proto files"));
-          }
+          return fileExtn !== protoFilesExtn;
         });
+        if (someFileIsNotAProto) {
+          reject(new ValidationError("The zip file should contain only proto files"));
+        }
         resolve();
       });
     });

--- a/packages/publisher-dapp/src/Pages/AiServiceCreation/PricingDistribution/UploadProto/index.js
+++ b/packages/publisher-dapp/src/Pages/AiServiceCreation/PricingDistribution/UploadProto/index.js
@@ -1,14 +1,18 @@
-import React, { Fragment, useCallback, useState, useEffect } from "react";
+import React, { Fragment, useCallback, useEffect, useState } from "react";
 import Typography from "@material-ui/core/Typography";
 import isEmpty from "lodash/isEmpty";
 import { useParams } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
+import JSZip from "jszip";
+import last from "lodash/last";
 
 import { useStyles } from "./styles";
 import SNETFileUpload from "shared/dist/components/SNETFileUpload";
 import AlertBox, { alertTypes } from "shared/dist/components/AlertBox";
 import { aiServiceDetailsActions } from "../../../../Services/Redux/actionCreators";
 import { assetTypes } from "../../../../Utils/FileUpload";
+import ValidationError from "shared/dist/utils/validationError";
+import { checkIfKnownError } from "shared/dist/utils/error";
 
 const UploadProto = ({ changeProtoFiles }) => {
   const classes = useStyles();
@@ -27,6 +31,22 @@ const UploadProto = ({ changeProtoFiles }) => {
     }
   }, [serviceDetails.assets.protoFiles.url, alert.message]);
 
+  const validateProtoFile = uploadedFile => {
+    const protoFilesExtn = "proto";
+    return new Promise((resolve, reject) => {
+      const zip = new JSZip();
+      zip.loadAsync(uploadedFile).then(entry => {
+        Object.values(entry.files).forEach(file => {
+          const fileExtn = last(file.name.split("."));
+          if (fileExtn !== protoFilesExtn) {
+            reject(new ValidationError("The zip file should contain only the proto files"));
+          }
+        });
+        resolve();
+      });
+    });
+  };
+
   const handleDrop = useCallback(
     async (acceptedFiles, rejectedFiles) => {
       setAlert({});
@@ -36,9 +56,9 @@ const UploadProto = ({ changeProtoFiles }) => {
       if (!isEmpty(acceptedFiles)) {
         try {
           const fileBlob = acceptedFiles[0];
+          await validateProtoFile(fileBlob);
           const { name, size, type } = fileBlob;
           setSelectedFile({ name, size, type });
-
           const { url } = await dispatch(
             aiServiceDetailsActions.uploadFile(assetTypes.SERVICE_PROTO_FILES, fileBlob, orgUuid, serviceUuid)
           );
@@ -46,6 +66,9 @@ const UploadProto = ({ changeProtoFiles }) => {
           dispatch(aiServiceDetailsActions.setServiceTouchedFlag(true));
           return setAlert({ type: alertTypes.SUCCESS, message: "File accepted" });
         } catch (error) {
+          if (checkIfKnownError(error)) {
+            return setAlert({ type: alertTypes.ERROR, message: error.message });
+          }
           setAlert({ type: alertTypes.ERROR, message: "Unable to upload file" });
         }
       }
@@ -66,8 +89,7 @@ const UploadProto = ({ changeProtoFiles }) => {
           rel="noopener noreferrer"
           target="_blank"
         >
-          {" "}
-          here{" "}
+          here
         </a>
       </Typography>
       <SNETFileUpload

--- a/packages/publisher-dapp/src/Pages/AiServiceCreation/PricingDistribution/UploadProto/index.js
+++ b/packages/publisher-dapp/src/Pages/AiServiceCreation/PricingDistribution/UploadProto/index.js
@@ -39,7 +39,7 @@ const UploadProto = ({ changeProtoFiles }) => {
         Object.values(entry.files).forEach(file => {
           const fileExtn = last(file.name.split("."));
           if (fileExtn !== protoFilesExtn) {
-            reject(new ValidationError("The zip file should contain only the proto files"));
+            reject(new ValidationError("The zip file should contain only proto files"));
           }
         });
         resolve();


### PR DESCRIPTION
 - Iterating the contents of the zip using `JSZip`
 - Checking if the extension of any of files inside zip is not `.proto`.
 - If yes, rejecting the promise with a validation error.
 - else promise will be resolved and the zip will be uploaded